### PR TITLE
Add Tentacle Linux build scripts and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # scummworks
 Organize Hebrew Adventure translation of SCUMM games in version control
+
+Day of the Tentacle — Linux build scripts: [`tentacle/linux/`](tentacle/linux/).

--- a/tentacle/.gitignore
+++ b/tentacle/.gitignore
@@ -1,4 +1,5 @@
 orig/
 orig.txt
+origtr.txt
 TENTACLE.000
 TENTACLE.001

--- a/tentacle/linux/README.md
+++ b/tentacle/linux/README.md
@@ -1,0 +1,84 @@
+# Day of the Tentacle — Linux build
+
+Shell workflows for **Day of the Tentacle** under [`tentacle/`](../): they mirror the Windows batch files at the `tentacle/` root and expect the same layout.
+
+## Windows (unchanged)
+
+Use [`../build.bat`](../build.bat) and [`../dump.bat`](../dump.bat) from `tentacle/` on Windows. This directory does not replace those files.
+
+## Layout
+
+All paths are relative to **`tentacle/`** (parent of `linux/`):
+
+| Path | Role |
+|------|------|
+| [`../strings.txt`](../strings.txt) | String table for injection |
+| [`../orig/`](../orig/) | Your local copy of original game data (`orig/TENTACLE.000`, …) — **not in git** |
+| `userdata/` | Input for `nutcracker sputm build` (must exist; contents depend on your nutcracker version) |
+| `../hash.txt` | Checksums of built `TENTACLE.000` / `.001` (tracked in git) |
+
+## Prerequisites
+
+- **bash** (not plain `sh`; scripts use `set -o pipefail`)
+- **nutcracker** on `PATH`, or set **`NUTCRACKER=/absolute/path/to/nutcracker`** (e.g. `~/.local/bin/nutcracker`). Upstream: [BLooperZ/nutcracker](https://github.com/BLooperZ/nutcracker), also on [PyPI](https://pypi.org/project/nutcracker/).
+- **md5deep** for `hash.txt` in the same format as Windows `md5deep64 -bz`. Install the **`md5deep`** package with your distro’s package manager. Examples:
+  - Debian / Ubuntu: `sudo apt install md5deep`
+  - RPM-based (dnf/yum): `sudo dnf install md5deep` or `sudo yum install md5deep`
+  - Arch: `sudo pacman -S md5deep`
+  - Immutable or minimal images: use your image’s package tool, or install inside **toolbox** / **distrobox** (or similar).
+- **dump only:** **scummtr** at `<repo>/utils/scummtr` (sibling of `tentacle/`), or set **`SCUMMTR=/path/to/scummtr`**. The repo does not ship `utils/`; mirror the Windows layout (`..\utils\scummtr` from `tentacle/`).
+
+## How to run
+
+From **`tentacle/`**:
+
+```bash
+./linux/build.sh
+./linux/dump.sh
+```
+
+From the **repository root**:
+
+```bash
+bash tentacle/linux/build.sh
+bash tentacle/linux/dump.sh
+```
+
+Scripts change into `tentacle/` themselves; you do not need to `cd` first.
+
+If you get “Permission denied”, run `chmod +x tentacle/linux/*.sh` or use `bash tentacle/linux/build.sh`.
+
+Debug paths:
+
+```bash
+VERBOSE=1 ./linux/build.sh
+```
+
+## Game data and copyright
+
+`orig/` contains **copyrighted game files**. It is **gitignored** and must not be committed. Obtain and copy game data legally; the translation repo does not distribute it.
+
+## Encoding
+
+Per [`.gitattributes`](../../.gitattributes), `strings*.txt` use **cp1255** in git. When editing [`../strings.txt`](../strings.txt), keep that encoding so Hebrew text is not corrupted.
+
+## `hash.txt` policy
+
+[`../hash.txt`](../hash.txt) is a **project artifact** in version control. A successful **build** overwrites it (and `TENTACLE.000` / `TENTACLE.001`). Commit a new `hash.txt` only when the team intends to record updated golden checksums (e.g. after translation or toolchain changes), not from accidental local builds with the wrong `orig/` / `userdata/`.
+
+## Warnings
+
+- **Overwrites:** `build.sh` replaces `TENTACLE.000`, `TENTACLE.001`, and `hash.txt` under `tentacle/`. Back up anything you care about before building.
+- **Case sensitivity:** Linux filesystems are usually case-sensitive. Paths must match exactly (e.g. `orig/TENTACLE.000`).
+- **userdata layout:** If `nutcracker sputm build` fails, compare your tree with a known-good setup or your nutcracker documentation; preflight only checks that `userdata/` exists.
+
+## Troubleshooting
+
+| Symptom | What to check |
+|---------|----------------|
+| `nutcracker not found` | `PATH`, or set `NUTCRACKER` to the executable |
+| `md5deep not found` | Install the `md5deep` package for your distro |
+| `userdata/ directory missing` | Create/populate `userdata/` as required by nutcracker |
+| `scummtr not found` | `utils/scummtr` next to `tentacle/`, or `SCUMMTR` |
+| Works on Windows but not Linux | Filename case under `orig/` |
+| Different `hash.txt` vs Windows | Different nutcracker / md5deep versions or `strings.txt` line endings |

--- a/tentacle/linux/build.sh
+++ b/tentacle/linux/build.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Day of the Tentacle — Linux build (mirrors tentacle/build.bat). Run from anywhere.
+set -euo pipefail
+
+die() {
+  printf '%s\n' "error: $*" >&2
+  exit 1
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+GAME_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$GAME_ROOT/.." && pwd)"
+cd "$GAME_ROOT"
+
+if [[ "${VERBOSE:-0}" == 1 ]]; then
+  printf 'GAME_ROOT=%s\n' "$GAME_ROOT" >&2
+  printf 'REPO_ROOT=%s\n' "$REPO_ROOT" >&2
+fi
+
+if [[ -n "${NUTCRACKER:-}" ]]; then
+  NUTCRACKER_CMD="$NUTCRACKER"
+  [[ -x "$NUTCRACKER_CMD" ]] || die "NUTCRACKER is set but not executable: $NUTCRACKER_CMD"
+else
+  command -v nutcracker &>/dev/null || die "nutcracker not found on PATH; install it or set NUTCRACKER=/path/to/nutcracker"
+  NUTCRACKER_CMD="nutcracker"
+fi
+
+command -v md5deep &>/dev/null || die "md5deep not found; install the md5deep package for your distribution"
+
+[[ -f strings.txt ]] || die "strings.txt missing in $GAME_ROOT"
+[[ -f orig/TENTACLE.000 ]] || die "orig/TENTACLE.000 missing (place game data under orig/)"
+[[ -d userdata ]] || die "userdata/ directory missing (required for nutcracker sputm build)"
+
+# Optional scummtr inject (disabled in build.bat):
+# "$REPO_ROOT/utils/scummtr" -w -g tentacle -if strings.txt -p .
+
+"$NUTCRACKER_CMD" sputm build --ref orig/TENTACLE.000 userdata/TENTACLE
+"$NUTCRACKER_CMD" sputm strings_inject -t strings.txt TENTACLE.000
+
+md5deep -bz TENTACLE.000 > hash.txt
+md5deep -bz TENTACLE.001 >> hash.txt

--- a/tentacle/linux/dump.sh
+++ b/tentacle/linux/dump.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Day of the Tentacle — Linux extract/dump (mirrors tentacle/dump.bat). Run from anywhere.
+set -euo pipefail
+
+die() {
+  printf '%s\n' "error: $*" >&2
+  exit 1
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+GAME_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$GAME_ROOT/.." && pwd)"
+cd "$GAME_ROOT"
+
+SCUMMTR="${SCUMMTR:-$REPO_ROOT/utils/scummtr}"
+
+if [[ "${VERBOSE:-0}" == 1 ]]; then
+  printf 'GAME_ROOT=%s\n' "$GAME_ROOT" >&2
+  printf 'REPO_ROOT=%s\n' "$REPO_ROOT" >&2
+  printf 'SCUMMTR=%s\n' "$SCUMMTR" >&2
+fi
+
+if [[ -n "${NUTCRACKER:-}" ]]; then
+  NUTCRACKER_CMD="$NUTCRACKER"
+  [[ -x "$NUTCRACKER_CMD" ]] || die "NUTCRACKER is set but not executable: $NUTCRACKER_CMD"
+else
+  command -v nutcracker &>/dev/null || die "nutcracker not found on PATH; install it or set NUTCRACKER=/path/to/nutcracker"
+  NUTCRACKER_CMD="nutcracker"
+fi
+
+[[ -f orig/TENTACLE.000 ]] || die "orig/TENTACLE.000 missing (place game data under orig/)"
+[[ -e "$SCUMMTR" ]] || die "scummtr not found at $SCUMMTR (set SCUMMTR=/path/to/scummtr or place binary at <repo>/utils/scummtr)"
+[[ -x "$SCUMMTR" ]] || die "scummtr is not executable: $SCUMMTR"
+
+"$NUTCRACKER_CMD" sputm strings_extract -t orig.txt orig/TENTACLE.000
+"$SCUMMTR" -w -g tentacle -oHf origtr.txt -p orig


### PR DESCRIPTION
Add tentacle/linux/build.sh and dump.sh, mirroring the Windows batch workflow.